### PR TITLE
Solving if and function

### DIFF
--- a/exercises/functions/functions1.rs
+++ b/exercises/functions/functions1.rs
@@ -1,8 +1,8 @@
 // functions1.rs
 // Make me compile! Execute `rustlings hint functions1` for hints :)
 
-// I AM NOT DONE
-
 fn main() {
     call_me();
 }
+
+fn call_me() {}

--- a/exercises/functions/functions2.rs
+++ b/exercises/functions/functions2.rs
@@ -1,13 +1,11 @@
 // functions2.rs
 // Make me compile! Execute `rustlings hint functions2` for hints :)
 
-// I AM NOT DONE
-
 fn main() {
     call_me(3);
 }
 
-fn call_me(num) {
+fn call_me(num: i32) {
     for i in 0..num {
         println!("Ring! Call number {}", i + 1);
     }

--- a/exercises/functions/functions3.rs
+++ b/exercises/functions/functions3.rs
@@ -1,10 +1,9 @@
 // functions3.rs
 // Make me compile! Execute `rustlings hint functions3` for hints :)
 
-// I AM NOT DONE
-
 fn main() {
-    call_me();
+    let count = 4;
+    call_me(count);
 }
 
 fn call_me(num: i32) {

--- a/exercises/functions/functions4.rs
+++ b/exercises/functions/functions4.rs
@@ -4,14 +4,12 @@
 // This store is having a sale where if the price is an even number, you get
 // 10 Rustbucks off, but if it's an odd number, it's 3 Rustbucks off.
 
-// I AM NOT DONE
-
 fn main() {
     let original_price = 51;
     println!("Your sale price is {}", sale_price(original_price));
 }
 
-fn sale_price(price: i32) -> {
+fn sale_price(price: i32) -> i32 {
     if is_even(price) {
         price - 10
     } else {

--- a/exercises/functions/functions5.rs
+++ b/exercises/functions/functions5.rs
@@ -1,13 +1,11 @@
 // functions5.rs
 // Make me compile! Execute `rustlings hint functions5` for hints :)
 
-// I AM NOT DONE
-
 fn main() {
     let answer = square(3);
     println!("The answer is {}", answer);
 }
 
 fn square(num: i32) -> i32 {
-    num * num;
+    num * num
 }

--- a/exercises/if/if1.rs
+++ b/exercises/if/if1.rs
@@ -1,13 +1,15 @@
 // if1.rs
 
-// I AM NOT DONE
-
 pub fn bigger(a: i32, b: i32) -> i32 {
     // Complete this function to return the bigger number!
     // Do not use:
     // - another function call
     // - additional variables
     // Execute `rustlings hint if1` for hints
+    if a > b {
+        return a;
+    }
+    b
 }
 
 // Don't mind this for now :)

--- a/exercises/if/if2.rs
+++ b/exercises/if/if2.rs
@@ -4,13 +4,13 @@
 // Step 2: Get the bar_for_fuzz and default_to_baz tests passing!
 // Execute the command `rustlings hint if2` if you want a hint :)
 
-// I AM NOT DONE
-
 pub fn fizz_if_foo(fizzish: &str) -> &str {
     if fizzish == "fizz" {
         "foo"
+    } else if fizzish == "fuzz" {
+        "bar"
     } else {
-        1
+        "baz"
     }
 }
 


### PR DESCRIPTION
functions in `Rust`

```rust
fn add(a: i32, b:i32) -> i32 {
    a + b // <- skip semi colon to return from the function 
}
```

```rust
fn bigger(a: i32, b: i32) -> i32 {
    if a > b {
        a // <- however would not work https://stackoverflow.com/a/51049939
           // have to use return a;
    }
    b
}
```

This is fine - 

```rust
fn fizz_if_foo(fizzish: &str) -> &str {
    if fizzish == "fizz" {
        "foo"
    } else if fizzish == "fuzz" {
        "bar"
    } else {
        "baz"
    }
}
```
